### PR TITLE
Fix strange issue on i386 / ZTS / php 5.5

### DIFF
--- a/env.c
+++ b/env.c
@@ -50,18 +50,20 @@ void char_ptr_dtor(char **str)
 #define char_ptr_dtor ZVAL_PTR_DTOR
 #endif
 
-/* {{{ php_env_init_globals
+/* {{{ PHP_GINIT_FUNCTION
  */
-static void php_env_init_globals(zend_env_globals *env_globals)
+PHP_GINIT_FUNCTION(env)
 {
 	env_globals->file = NULL;
 	env_globals->parse_err = 0;
 	env_globals->vars = (HashTable*)pemalloc(sizeof(HashTable), 1);
 	zend_hash_init(env_globals->vars, 128, NULL, char_ptr_dtor, 1);
 }
-
 /* }}} */
-static void php_env_shutdown_globals(zend_env_globals *env_globals)
+
+/* {{{ PHP_GSHUTDOWN_FUNCTION
+ */
+PHP_GSHUTDOWN_FUNCTION(env)
 {
 	env_globals->file = NULL;
 	env_globals->parse_err = 0;
@@ -72,7 +74,6 @@ static void php_env_shutdown_globals(zend_env_globals *env_globals)
  */
 PHP_MINIT_FUNCTION(env)
 {
-	ZEND_INIT_MODULE_GLOBALS(env, php_env_init_globals, php_env_shutdown_globals);
 	REGISTER_INI_ENTRIES();
 
 	php_env_module_init(ENV_G(vars) TSRMLS_CC);
@@ -144,7 +145,11 @@ zend_module_entry env_module_entry = {
 	PHP_RSHUTDOWN(env),	/* Replace with NULL if there's nothing to do at request end */
 	PHP_MINFO(env),
 	PHP_ENV_VERSION,
-	STANDARD_MODULE_PROPERTIES
+	PHP_MODULE_GLOBALS(env),   /* globals descriptor */
+	PHP_GINIT(env),            /* globals ctor */
+	PHP_GSHUTDOWN(env),        /* globals dtor */
+	NULL,                      /* post deactivate */
+	STANDARD_MODULE_PROPERTIES_EX
 };
 /* }}} */
 

--- a/php5/php_env.c
+++ b/php5/php_env.c
@@ -61,7 +61,13 @@ void php_env_request_init(HashTable *vars TSRMLS_DC)
 		type = zend_hash_get_current_key_ex(vars, &str, &len, &idx, 0, NULL);
 		if (type == HASH_KEY_IS_STRING) {
 			if ((zend_hash_get_current_data(vars, (void**)&data) == SUCCESS)) {
+                            if (str[len]) { /* Workaroung php 5.5 / ZTS / i386 issue */
+				char *tmp = estrndup(str, len);
+				setenv(tmp, *data, 1);
+				efree(tmp);
+                            } else {
 				setenv(str, *data, 1);
+                            }
 			}
 		}
 	}


### PR DESCRIPTION
running the build on various env. I encounter a very strange bug (i386 / ZTS / php 5.5 only).

The key of the first entry of the vars HashTable is not null terminated... :(

As this will probably can't be fixed in 5.5 (security only), the first commit introduce a workaround.

The second commit is only a cleanup to use the GINIT/GSHUTDOWN (to avoid possible issue with ZTS mode).

Notice, perhaps, will be simpler to not dynamically allocate the "vars"  HashTable
