### PR TITLE
fix PHP 7 dtor, fix #3

### DIFF
--- a/env.c
+++ b/env.c
@@ -41,18 +41,10 @@ PHP_INI_END()
 /* }}} */
 
 
-#if PHP_VERSION_ID < 70000
 void char_ptr_dtor(char **str)
 {
 	free(*str);
 }
-#else
-void char_ptr_dtor(zval **str)
-{
-	free(Z_STRVAL_PP(str));
-	free(*str);
-}
-#endif
 
 /* {{{ PHP_GINIT_FUNCTION
  */


### PR DESCRIPTION
The memory free here is the one allocated in php_env.c / php_env_ini_parser_cb, so by strndup in both case.

Valgrind seems happy (php run-tests.php -m, php 5.6.16 and 7.0.1)
